### PR TITLE
fix: fix error in empty sampling

### DIFF
--- a/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
+++ b/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
@@ -1,12 +1,9 @@
 import math
-
 import numpy as np
 import torch
 import torch.nn as nn
 
-from ....ops.pointnet2.pointnet2_stack import (
-    pointnet2_modules as pointnet2_stack_modules,
-)
+from ....ops.pointnet2.pointnet2_stack import pointnet2_modules as pointnet2_stack_modules
 from ....ops.pointnet2.pointnet2_stack import pointnet2_utils as pointnet2_stack_utils
 from ....utils import common_utils
 
@@ -411,9 +408,6 @@ class VoxelSetAbstraction(nn.Module):
         batch_dict['point_features_before_fusion'] = point_features.view(-1, point_features.shape[-1])
         point_features = self.vsa_point_feature_fusion(point_features.view(-1, point_features.shape[-1]))
 
-        batch_dict['point_features'] = point_features  # (BxN, C)
-        batch_dict['point_coords'] = keypoints  # (BxN, 4)
-        return batch_dict
         batch_dict['point_features'] = point_features  # (BxN, C)
         batch_dict['point_coords'] = keypoints  # (BxN, 4)
         return batch_dict

--- a/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
+++ b/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
@@ -1,9 +1,12 @@
 import math
+
 import numpy as np
 import torch
 import torch.nn as nn
 
-from ....ops.pointnet2.pointnet2_stack import pointnet2_modules as pointnet2_stack_modules
+from ....ops.pointnet2.pointnet2_stack import (
+    pointnet2_modules as pointnet2_stack_modules,
+)
 from ....ops.pointnet2.pointnet2_stack import pointnet2_utils as pointnet2_stack_utils
 from ....utils import common_utils
 
@@ -70,7 +73,9 @@ def sample_points_with_roi(rois, points, sample_radius_with_roi, num_max_points_
             start_idx += num_max_points_of_part
         point_mask = torch.cat(point_mask_list, dim=0)
 
-    sampled_points = points[:1] if point_mask.sum() == 0 else points[point_mask, :]
+    if point_mask.sum() == 0:
+        point_mask[0] = True
+    sampled_points = points[point_mask, :]
 
     return sampled_points, point_mask
 
@@ -406,6 +411,9 @@ class VoxelSetAbstraction(nn.Module):
         batch_dict['point_features_before_fusion'] = point_features.view(-1, point_features.shape[-1])
         point_features = self.vsa_point_feature_fusion(point_features.view(-1, point_features.shape[-1]))
 
+        batch_dict['point_features'] = point_features  # (BxN, C)
+        batch_dict['point_coords'] = keypoints  # (BxN, 4)
+        return batch_dict
         batch_dict['point_features'] = point_features  # (BxN, C)
         batch_dict['point_coords'] = keypoints  # (BxN, 4)
         return batch_dict

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def write_version_to_file(version, target_file):
 
 
 if __name__ == '__main__':
-    version = '0.6.0+%s' % get_git_commit_number()
+    version = '0.6.1+%s' % get_git_commit_number()
     write_version_to_file(version, 'pcdet/version.py')
 
     setup(


### PR DESCRIPTION
This PR fixes a bug that can appear in very unstable trainings or in early training. Without this fix we cannot perform all the experiments successfully since the model crash.

The bug consists into a non coherent sampling mask that can be returned as empty even if a point is always sampled in any case.