### PR TITLE
chore: fix assertion to be more lenient

### DIFF
--- a/pcdet/models/dense_heads/point_head_template.py
+++ b/pcdet/models/dense_heads/point_head_template.py
@@ -66,8 +66,8 @@ class PointHeadTemplate(nn.Module):
 
         """
         assert len(points.shape) == 2 and points.shape[1] == 4, 'points.shape=%s' % str(points.shape)
-        assert len(gt_boxes.shape) == 3 and gt_boxes.shape[2] == 9, 'gt_boxes.shape=%s' % str(gt_boxes.shape)
-        assert extend_gt_boxes is None or len(extend_gt_boxes.shape) == 3 and gt_boxes.shape[2] == 9, \
+        assert len(gt_boxes.shape) == 3 and gt_boxes.shape[2] >= 8, 'gt_boxes.shape=%s' % str(gt_boxes.shape)
+        assert extend_gt_boxes is None or len(extend_gt_boxes.shape) == 3 and extend_gt_boxes.shape[2] >= 8, \
             'extend_gt_boxes.shape=%s' % str(extend_gt_boxes.shape)
         assert set_ignore_flag != use_ball_constraint, 'Choose one only!'
         batch_size = gt_boxes.shape[0]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def write_version_to_file(version, target_file):
 
 
 if __name__ == '__main__':
-    version = '0.7.0+%s' % get_git_commit_number()
+    version = '0.7.1+%s' % get_git_commit_number()
     write_version_to_file(version, 'pcdet/version.py')
 
     setup(


### PR DESCRIPTION
## What /why

These assertions were set to check bbox length to be 9, but actually they only need to be size 8 (or larger is also fine).
This makes the recent auxilliary class addition backward compatible with old bbox size (support both length 8 and 9 bbox)