### PR TITLE
fix: fix data type in `target_assigner` / `anchor_generator`

### DIFF
--- a/pcdet/models/dense_heads/target_assigner/anchor_generator.py
+++ b/pcdet/models/dense_heads/target_assigner/anchor_generator.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 
 

--- a/pcdet/models/dense_heads/target_assigner/anchor_generator.py
+++ b/pcdet/models/dense_heads/target_assigner/anchor_generator.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 
@@ -32,10 +33,10 @@ class AnchorGenerator(object):
                 x_offset, y_offset = 0, 0
 
             x_shifts = torch.arange(
-                self.anchor_range[0] + x_offset, self.anchor_range[3] + 1e-5, step=x_stride, dtype=torch.float32,
+                self.anchor_range[0] + x_offset, self.anchor_range[3] + 1e-5, step=x_stride, dtype=np.float32,
             ).cuda()
             y_shifts = torch.arange(
-                self.anchor_range[1] + y_offset, self.anchor_range[4] + 1e-5, step=y_stride, dtype=torch.float32,
+                self.anchor_range[1] + y_offset, self.anchor_range[4] + 1e-5, step=y_stride, dtype=np.float32,
             ).cuda()
             z_shifts = x_shifts.new_tensor(anchor_height)
 

--- a/pcdet/models/dense_heads/target_assigner/anchor_generator.py
+++ b/pcdet/models/dense_heads/target_assigner/anchor_generator.py
@@ -33,10 +33,10 @@ class AnchorGenerator(object):
                 x_offset, y_offset = 0, 0
 
             x_shifts = torch.arange(
-                self.anchor_range[0] + x_offset, self.anchor_range[3] + 1e-5, step=np.float32(x_stride), dtype=torch.float32,
+                float(self.anchor_range[0] + x_offset), float(self.anchor_range[3] + 1e-5), step=float(x_stride), dtype=torch.float32,
             ).cuda()
             y_shifts = torch.arange(
-                self.anchor_range[1] + y_offset, self.anchor_range[4] + 1e-5, step=np.float32(y_stride), dtype=torch.float32,
+                float(self.anchor_range[1] + y_offset), float(self.anchor_range[4] + 1e-5), step=float(y_stride), dtype=torch.float32,
             ).cuda()
             z_shifts = x_shifts.new_tensor(anchor_height)
 

--- a/pcdet/models/dense_heads/target_assigner/anchor_generator.py
+++ b/pcdet/models/dense_heads/target_assigner/anchor_generator.py
@@ -33,10 +33,10 @@ class AnchorGenerator(object):
                 x_offset, y_offset = 0, 0
 
             x_shifts = torch.arange(
-                self.anchor_range[0] + x_offset, self.anchor_range[3] + 1e-5, step=x_stride, dtype=np.float32,
+                self.anchor_range[0] + x_offset, self.anchor_range[3] + 1e-5, step=np.float32(x_stride), dtype=torch.float32,
             ).cuda()
             y_shifts = torch.arange(
-                self.anchor_range[1] + y_offset, self.anchor_range[4] + 1e-5, step=y_stride, dtype=np.float32,
+                self.anchor_range[1] + y_offset, self.anchor_range[4] + 1e-5, step=np.float32(y_stride), dtype=torch.float32,
             ).cuda()
             z_shifts = x_shifts.new_tensor(anchor_height)
 


### PR DESCRIPTION
This PR includes a minor fix to be able to run [the test inference script in the OSS project](https://github.com/promaton/ios/blob/main/projects/oss/third_party/openpcdet/test/pv_rcnn_inference.py).

The followup will be done within the scope of https://github.com/promaton/ios/pull/2901, where we enable a build / publish workflow, building the wheel for certain 1) Torch, CUDA, cumm and spconv versions and 2) then testing it works properly + 3) publishing to Promaton PyPI. This fix is related to the 2nd step.